### PR TITLE
Add ssh-rsa host key algorithm

### DIFF
--- a/pyruckus/RuckusSSH.py
+++ b/pyruckus/RuckusSSH.py
@@ -35,7 +35,7 @@ class RuckusSSH(spawn):
         self, host: str, username=None, password="", login_timeout=10
     ) -> bool:
         """Log into the Ruckus device."""
-        spawn._spawn(self, f"ssh {host}")
+        spawn._spawn(self, f"ssh -oHostKeyAlgorithms=+ssh-rsa {host}")
 
         login_regex_array = [
             "Please login: ",


### PR DESCRIPTION
This PR adds the `ssh-rsa` host key algorithm. `ssh-rsa` is not secure anymore and is disabled in newer OpenSSH versions, but that is the only algorithm supported on Ruckus devices.

Fixes #1.